### PR TITLE
Add a basic support for the categorical type.

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -109,6 +109,7 @@ if (
 
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes.base import Index
+from databricks.koalas.indexes.category import CategoricalIndex
 from databricks.koalas.indexes.datetimes import DatetimeIndex
 from databricks.koalas.indexes.multi import MultiIndex
 from databricks.koalas.indexes.numeric import Float64Index, Int64Index
@@ -128,6 +129,7 @@ __all__ = [  # noqa: F405
     "MultiIndex",
     "Int64Index",
     "Float64Index",
+    "CategoricalIndex",
     "DatetimeIndex",
     "sql",
     "range",

--- a/databricks/koalas/categorical.py
+++ b/databricks/koalas/categorical.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+if TYPE_CHECKING:
+    import databricks.koalas as ks
+
+
+class CategoricalAccessor(object):
+    """
+    Accessor object for categorical properties of the Series values.
+
+    Examples
+    --------
+    >>> s = ks.Series(list("abbccc"), dtype="category")
+    >>> s  # doctest: +SKIP
+    0    a
+    1    b
+    2    b
+    3    c
+    4    c
+    5    c
+    dtype: category
+    Categories (3, object): ['a', 'b', 'c']
+
+    >>> s.cat.categories
+    Index(['a', 'b', 'c'], dtype='object')
+
+    >>> s.cat.codes
+    0    0
+    1    1
+    2    1
+    3    2
+    4    2
+    5    2
+    dtype: int8
+    """
+
+    def __init__(self, series: "ks.Series"):
+        if not isinstance(series.dtype, CategoricalDtype):
+            raise ValueError("Cannot call CategoricalAccessor on type {}".format(series.dtype))
+        self._data = series
+
+    @property
+    def categories(self) -> pd.Index:
+        """
+        The categories of this categorical.
+
+        Examples
+        --------
+        >>> s = ks.Series(list("abbccc"), dtype="category")
+        >>> s  # doctest: +SKIP
+        0    a
+        1    b
+        2    b
+        3    c
+        4    c
+        5    c
+        dtype: category
+        Categories (3, object): ['a', 'b', 'c']
+
+        >>> s.cat.categories
+        Index(['a', 'b', 'c'], dtype='object')
+        """
+        return self._data.dtype.categories
+
+    @categories.setter
+    def categories(self, categories) -> None:
+        raise NotImplementedError()
+
+    @property
+    def ordered(self) -> bool:
+        """
+        Whether the categories have an ordered relationship.
+
+        Examples
+        --------
+        >>> s = ks.Series(list("abbccc"), dtype="category")
+        >>> s  # doctest: +SKIP
+        0    a
+        1    b
+        2    b
+        3    c
+        4    c
+        5    c
+        dtype: category
+        Categories (3, object): ['a', 'b', 'c']
+
+        >>> s.cat.ordered
+        False
+        """
+        return self._data.dtype.ordered
+
+    @property
+    def codes(self) -> "ks.Series":
+        """
+        Return Series of codes as well as the index.
+
+        Examples
+        --------
+        >>> s = ks.Series(list("abbccc"), dtype="category")
+        >>> s  # doctest: +SKIP
+        0    a
+        1    b
+        2    b
+        3    c
+        4    c
+        5    c
+        dtype: category
+        Categories (3, object): ['a', 'b', 'c']
+
+        >>> s.cat.codes
+        0    0
+        1    1
+        2    1
+        3    2
+        4    2
+        5    2
+        dtype: int8
+        """
+        return self._data._with_new_scol(self._data.spark.column).rename()
+
+    def add_categories(self, new_categories, inplace: bool = False):
+        raise NotImplementedError()
+
+    def as_ordered(self, inplace: bool = False):
+        raise NotImplementedError()
+
+    def as_unordered(self, inplace: bool = False):
+        raise NotImplementedError()
+
+    def remove_categories(self, removals, inplace: bool = False):
+        raise NotImplementedError()
+
+    def remove_unused_categories(self):
+        raise NotImplementedError()
+
+    def rename_categories(self, new_categories, inplace: bool = False):
+        raise NotImplementedError()
+
+    def reorder_categories(self, new_categories, ordered: bool = None, inplace: bool = False):
+        raise NotImplementedError()
+
+    def set_categories(
+        self, new_categories, ordered: bool = None, rename: bool = False, inplace: bool = False
+    ):
+        raise NotImplementedError()

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -32,7 +32,7 @@ from pandas.api.types import (
 )
 from pandas.core.accessor import CachedAccessor
 from pandas.io.formats.printing import pprint_thing
-from pandas.api.types import is_hashable
+from pandas.api.types import CategoricalDtype, is_hashable
 from pandas._libs import lib
 
 from pyspark import sql as spark
@@ -155,12 +155,15 @@ class Index(IndexOpsMixin):
 
     @staticmethod
     def _new_instance(anchor: DataFrame) -> "Index":
+        from databricks.koalas.indexes.category import CategoricalIndex
         from databricks.koalas.indexes.datetimes import DatetimeIndex
         from databricks.koalas.indexes.multi import MultiIndex
         from databricks.koalas.indexes.numeric import Float64Index, Int64Index
 
         if anchor._internal.index_level > 1:
             instance = object.__new__(MultiIndex)
+        elif isinstance(anchor._internal.index_dtypes[0], CategoricalDtype):
+            instance = object.__new__(CategoricalIndex)
         elif isinstance(
             anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]), IntegralType
         ):

--- a/databricks/koalas/indexes/category.py
+++ b/databricks/koalas/indexes/category.py
@@ -1,0 +1,187 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from functools import partial
+from typing import Any
+
+import pandas as pd
+from pandas.api.types import is_hashable
+
+from databricks import koalas as ks
+from databricks.koalas.indexes.base import Index
+from databricks.koalas.missing.indexes import MissingPandasLikeCategoricalIndex
+from databricks.koalas.series import Series
+
+
+class CategoricalIndex(Index):
+    """
+    Index based on an underlying `Categorical`.
+
+    CategoricalIndex can only take on a limited,
+    and usually fixed, number of possible values (`categories`). Also,
+    it might have an order, but numerical operations
+    (additions, divisions, ...) are not possible.
+
+    Parameters
+    ----------
+    data : array-like (1-dimensional)
+        The values of the categorical. If `categories` are given, values not in
+        `categories` will be replaced with NaN.
+    categories : index-like, optional
+        The categories for the categorical. Items need to be unique.
+        If the categories are not given here (and also not in `dtype`), they
+        will be inferred from the `data`.
+    ordered : bool, optional
+        Whether or not this categorical is treated as an ordered
+        categorical. If not given here or in `dtype`, the resulting
+        categorical will be unordered.
+    dtype : CategoricalDtype or "category", optional
+        If :class:`CategoricalDtype`, cannot be used together with
+        `categories` or `ordered`.
+    copy : bool, default False
+        Make a copy of input ndarray.
+    name : object, optional
+        Name to be stored in the index.
+
+    See Also
+    --------
+    Index : The base Koalas Index type.
+
+    Examples
+    --------
+    >>> ks.CategoricalIndex(["a", "b", "c", "a", "b", "c"])  # doctest: +NORMALIZE_WHITESPACE
+    CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
+                     categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+    ``CategoricalIndex`` can also be instantiated from a ``Categorical``:
+
+    >>> c = pd.Categorical(["a", "b", "c", "a", "b", "c"])
+    >>> ks.CategoricalIndex(c)  # doctest: +NORMALIZE_WHITESPACE
+    CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
+                     categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+    Ordered ``CategoricalIndex`` can have a min and max value.
+
+    >>> ci = ks.CategoricalIndex(
+    ...     ["a", "b", "c", "a", "b", "c"], ordered=True, categories=["c", "b", "a"]
+    ... )
+    >>> ci  # doctest: +NORMALIZE_WHITESPACE
+    CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
+                     categories=['c', 'b', 'a'], ordered=True, dtype='category')
+
+    From a Series:
+
+    >>> s = ks.Series(["a", "b", "c", "a", "b", "c"], index=[10, 20, 30, 40, 50, 60])
+    >>> ks.CategoricalIndex(s)  # doctest: +NORMALIZE_WHITESPACE
+    CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
+                     categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+    From an Index:
+
+    >>> idx = ks.Index(["a", "b", "c", "a", "b", "c"])
+    >>> ks.CategoricalIndex(idx)  # doctest: +NORMALIZE_WHITESPACE
+    CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
+                     categories=['a', 'b', 'c'], ordered=False, dtype='category')
+    """
+
+    def __new__(cls, data=None, categories=None, ordered=None, dtype=None, copy=False, name=None):
+        if not is_hashable(name):
+            raise TypeError("Index.name must be a hashable type")
+
+        if isinstance(data, (Series, Index)):
+            if dtype is None:
+                dtype = "category"
+            return Index(data, dtype=dtype, copy=copy, name=name)
+
+        return ks.from_pandas(
+            pd.CategoricalIndex(
+                data=data, categories=categories, ordered=ordered, dtype=dtype, name=name
+            )
+        )
+
+    @property
+    def codes(self) -> Index:
+        """
+        The category codes of this categorical.
+
+        Codes are an Index of integers which are the positions of the actual
+        values in the categories Index.
+
+        There is no setter, use the other categorical methods and the normal item
+        setter to change values in the categorical.
+
+        Returns
+        -------
+        Index
+            A non-writable view of the `codes` Index.
+
+        Examples
+        --------
+        >>> idx = ks.CategoricalIndex(list("abbccc"))
+        >>> idx  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
+                         categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+        >>> idx.codes
+        Int64Index([0, 1, 1, 2, 2, 2], dtype='int64')
+        """
+        return self._with_new_scol(self.spark.column).rename(None)
+
+    @property
+    def categories(self) -> pd.Index:
+        """
+        The categories of this categorical.
+
+        Examples
+        --------
+        >>> idx = ks.CategoricalIndex(list("abbccc"))
+        >>> idx  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
+                         categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+        >>> idx.categories
+        Index(['a', 'b', 'c'], dtype='object')
+        """
+        return self.dtype.categories
+
+    @categories.setter
+    def categories(self, categories):
+        raise NotImplementedError()
+
+    @property
+    def ordered(self) -> bool:
+        """
+        Whether the categories have an ordered relationship.
+
+        Examples
+        --------
+        >>> idx = ks.CategoricalIndex(list("abbccc"))
+        >>> idx  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
+                         categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+        >>> idx.ordered
+        False
+        """
+        return self.dtype.ordered
+
+    def __getattr__(self, item: str) -> Any:
+        if hasattr(MissingPandasLikeCategoricalIndex, item):
+            property_or_func = getattr(MissingPandasLikeCategoricalIndex, item)
+            if isinstance(property_or_func, property):
+                return property_or_func.fget(self)  # type: ignore
+            else:
+                return partial(property_or_func, self)
+        raise AttributeError("'CategoricalIndex' object has no attribute '{}'".format(item))

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -121,6 +121,22 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
     std = _unsupported_function("std", cls="DatetimeIndex")
 
 
+class MissingPandasLikeCategoricalIndex(MissingPandasLikeIndex):
+
+    # Functions
+    rename_categories = _unsupported_function("rename_categories", cls="CategoricalIndex")
+    reorder_categories = _unsupported_function("reorder_categories", cls="CategoricalIndex")
+    add_categories = _unsupported_function("add_categories", cls="CategoricalIndex")
+    remove_categories = _unsupported_function("remove_categories", cls="CategoricalIndex")
+    remove_unused_categories = _unsupported_function(
+        "remove_unused_categories", cls="CategoricalIndex"
+    )
+    set_categories = _unsupported_function("set_categories", cls="CategoricalIndex")
+    as_ordered = _unsupported_function("as_ordered", cls="CategoricalIndex")
+    as_unordered = _unsupported_function("as_unordered", cls="CategoricalIndex")
+    map = _unsupported_function("map", cls="CategoricalIndex")
+
+
 class MissingPandasLikeMultiIndex(object):
 
     # Deprecated properties

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -49,6 +49,7 @@ from pyspark.sql.window import Window
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.accessors import KoalasSeriesMethods
+from databricks.koalas.categorical import CategoricalAccessor
 from databricks.koalas.config import get_option
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.exceptions import SparkPandasIndexingError
@@ -5844,6 +5845,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     # ----------------------------------------------------------------------
     dt = CachedAccessor("dt", DatetimeMethods)
     str = CachedAccessor("str", StringMethods)
+    cat = CachedAccessor("cat", CategoricalAccessor)
     plot = CachedAccessor("plot", KoalasPlotAccessor)
 
     # ----------------------------------------------------------------------

--- a/databricks/koalas/tests/indexes/test_category.py
+++ b/databricks/koalas/tests/indexes/test_category.py
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from distutils.version import LooseVersion
+
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+import databricks.koalas as ks
+from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+class CategoricalIndexTest(ReusedSQLTestCase, TestUtils):
+    def test_categorical_index(self):
+        pidx = pd.CategoricalIndex([1, 2, 3])
+        kidx = ks.CategoricalIndex([1, 2, 3])
+
+        self.assert_eq(kidx, pidx)
+        self.assert_eq(kidx.categories, pidx.categories)
+        self.assert_eq(kidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(kidx.ordered, pidx.ordered)
+
+        pidx = pd.Index([1, 2, 3], dtype="category")
+        kidx = ks.Index([1, 2, 3], dtype="category")
+
+        self.assert_eq(kidx, pidx)
+        self.assert_eq(kidx.categories, pidx.categories)
+        self.assert_eq(kidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(kidx.ordered, pidx.ordered)
+
+        pdf = pd.DataFrame(
+            {
+                "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
+                "b": pd.Categorical(["a", "b", "c", "a", "b", "c"], categories=["c", "b", "a"]),
+            },
+            index=pd.Categorical([10, 20, 30, 20, 30, 10], categories=[30, 10, 20], ordered=True),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        pidx = pdf.set_index("b").index
+        kidx = kdf.set_index("b").index
+
+        self.assert_eq(kidx, pidx)
+        self.assert_eq(kidx.categories, pidx.categories)
+        self.assert_eq(kidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(kidx.ordered, pidx.ordered)
+
+        pidx = pdf.set_index(["a", "b"]).index.get_level_values(0)
+        kidx = kdf.set_index(["a", "b"]).index.get_level_values(0)
+
+        self.assert_eq(kidx, pidx)
+        self.assert_eq(kidx.categories, pidx.categories)
+        self.assert_eq(kidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(kidx.ordered, pidx.ordered)
+
+    def test_astype(self):
+        pidx = pd.Index(["a", "b", "c"])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(kidx.astype("category"), pidx.astype("category"))
+        self.assert_eq(
+            kidx.astype(CategoricalDtype(["c", "a", "b"])),
+            pidx.astype(CategoricalDtype(["c", "a", "b"])),
+        )
+
+        pcidx = pidx.astype(CategoricalDtype(["c", "a", "b"]))
+        kcidx = kidx.astype(CategoricalDtype(["c", "a", "b"]))
+
+        self.assert_eq(kcidx.astype("category"), pcidx.astype("category"))
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
+            self.assert_eq(
+                kcidx.astype(CategoricalDtype(["b", "c", "a"])),
+                pcidx.astype(CategoricalDtype(["b", "c", "a"])),
+            )
+        else:
+            self.assert_eq(
+                kcidx.astype(CategoricalDtype(["b", "c", "a"])),
+                pidx.astype(CategoricalDtype(["b", "c", "a"])),
+            )
+
+        self.assert_eq(kcidx.astype(str), pcidx.astype(str))
+
+    def test_factorize(self):
+        pidx = pd.CategoricalIndex([1, 2, 3, None])
+        kidx = ks.from_pandas(pidx)
+
+        pcodes, puniques = pidx.factorize()
+        kcodes, kuniques = kidx.factorize()
+
+        self.assert_eq(kcodes.tolist(), pcodes.tolist())
+        self.assert_eq(kuniques, puniques)
+
+        pcodes, puniques = pidx.factorize(na_sentinel=-2)
+        kcodes, kuniques = kidx.factorize(na_sentinel=-2)
+
+        self.assert_eq(kcodes.tolist(), pcodes.tolist())
+        self.assert_eq(kuniques, puniques)

--- a/databricks/koalas/tests/test_categorical.py
+++ b/databricks/koalas/tests/test_categorical.py
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from distutils.version import LooseVersion
+
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+import databricks.koalas as ks
+from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+class CategoricalTest(ReusedSQLTestCase, TestUtils):
+    def test_categorical_frame(self):
+        pdf = pd.DataFrame(
+            {
+                "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
+                "b": pd.Categorical(["a", "b", "c", "a", "b", "c"], categories=["c", "b", "a"]),
+            },
+            index=pd.Categorical([10, 20, 30, 20, 30, 10], categories=[30, 10, 20], ordered=True),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(kdf.a, pdf.a)
+        self.assert_eq(kdf.b, pdf.b)
+        self.assert_eq(kdf.index, pdf.index)
+
+        self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kdf.sort_values("b"), pdf.sort_values("b"))
+
+    def test_categorical_series(self):
+        pser = pd.Series([1, 2, 3], dtype="category")
+        kser = ks.Series([1, 2, 3], dtype="category")
+
+        self.assert_eq(kser, pser)
+        self.assert_eq(kser.cat.categories, pser.cat.categories)
+        self.assert_eq(kser.cat.codes, pser.cat.codes)
+        self.assert_eq(kser.cat.ordered, pser.cat.ordered)
+
+    def test_astype(self):
+        pser = pd.Series(["a", "b", "c"])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.astype("category"), pser.astype("category"))
+        self.assert_eq(
+            kser.astype(CategoricalDtype(["c", "a", "b"])),
+            pser.astype(CategoricalDtype(["c", "a", "b"])),
+        )
+
+        pcser = pser.astype(CategoricalDtype(["c", "a", "b"]))
+        kcser = kser.astype(CategoricalDtype(["c", "a", "b"]))
+
+        self.assert_eq(kcser.astype("category"), pcser.astype("category"))
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
+            self.assert_eq(
+                kcser.astype(CategoricalDtype(["b", "c", "a"])),
+                pcser.astype(CategoricalDtype(["b", "c", "a"])),
+            )
+        else:
+            self.assert_eq(
+                kcser.astype(CategoricalDtype(["b", "c", "a"])),
+                pser.astype(CategoricalDtype(["b", "c", "a"])),
+            )
+
+        self.assert_eq(kcser.astype(str), pcser.astype(str))
+
+    def test_factorize(self):
+        pser = pd.Series(["a", "b", "c", None], dtype=CategoricalDtype(["c", "a", "d", "b"]))
+        kser = ks.from_pandas(pser)
+
+        pcodes, puniques = pser.factorize()
+        kcodes, kuniques = kser.factorize()
+
+        self.assert_eq(kcodes.tolist(), pcodes.tolist())
+        self.assert_eq(kuniques, puniques)
+
+        pcodes, puniques = pser.factorize(na_sentinel=-2)
+        kcodes, kuniques = kser.factorize(na_sentinel=-2)
+
+        self.assert_eq(kcodes.tolist(), pcodes.tolist())
+        self.assert_eq(kuniques, puniques)

--- a/databricks/koalas/usage_logging/__init__.py
+++ b/databricks/koalas/usage_logging/__init__.py
@@ -30,6 +30,7 @@ from databricks.koalas.frame import DataFrame
 from databricks.koalas.datetimes import DatetimeMethods
 from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 from databricks.koalas.indexes.base import Index
+from databricks.koalas.indexes.category import CategoricalIndex
 from databricks.koalas.indexes.datetimes import DatetimeIndex
 from databricks.koalas.indexes.multi import MultiIndex
 from databricks.koalas.indexes.numeric import Float64Index, Int64Index
@@ -39,6 +40,7 @@ from databricks.koalas.missing.groupby import (
     MissingPandasLikeSeriesGroupBy,
 )
 from databricks.koalas.missing.indexes import (
+    MissingPandasLikeCategoricalIndex,
     MissingPandasLikeDatetimeIndex,
     MissingPandasLikeIndex,
     MissingPandasLikeMultiIndex,
@@ -87,6 +89,7 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         MultiIndex,
         Int64Index,
         Float64Index,
+        CategoricalIndex,
         DatetimeIndex,
         DataFrameGroupBy,
         SeriesGroupBy,
@@ -153,6 +156,7 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         (pd.Series, MissingPandasLikeSeries),
         (pd.Index, MissingPandasLikeIndex),
         (pd.MultiIndex, MissingPandasLikeMultiIndex),
+        (pd.CategoricalIndex, MissingPandasLikeCategoricalIndex),
         (pd.DatetimeIndex, MissingPandasLikeDatetimeIndex),
         (pd.core.groupby.DataFrameGroupBy, MissingPandasLikeDataFrameGroupBy),
         (pd.core.groupby.SeriesGroupBy, MissingPandasLikeSeriesGroupBy),


### PR DESCRIPTION
Recreated from original PR: https://github.com/databricks/koalas/pull/2064

Experimental.

Add a basic support for the categorical type.

```py
>>> s = ks.Series(list("abbccc"), dtype="category")
>>> s
0    a
1    b
2    b
3    c
4    c
5    c
dtype: category
Categories (3, object): ['a', 'b', 'c']
>>> s.cat.categories
Index(['a', 'b', 'c'], dtype='object')
>>> s.cat.codes
0    0
1    1
2    1
3    2
4    2
5    2
dtype: int8

>>> idx = ks.CategoricalIndex(list("abbccc"))
>>> idx
CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
             ...